### PR TITLE
Support case-sensitive file-systems + Add -std=c++11

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ TARGET = fieldviz
 CLTARGET = fieldgen
 CC = g++
 LD = g++
-CFLAGS = -g -Wall -Wno-deprecated -Werror -Wno-error=deprecated-declarations -ansi -pedantic  $(DDG_INCLUDE_PATH) -I./include -I./src
+CFLAGS = -g -std=c++11 -Wall -Wno-deprecated -Werror -Wno-error=deprecated-declarations -ansi -pedantic  $(DDG_INCLUDE_PATH) -I./include -I./src
 LFLAGS = -g -Wall -Wno-deprecated -Werror -pedantic $(DDG_LIBRARY_PATH)
 LIBS = $(DDG_OPENGL_LIBS) $(DDG_SUITESPARSE_LIBS) $(DDG_BLAS_LIBS)
 CLLIBS = $(DDG_SUITESPARSE_LIBS) $(DDG_BLAS_LIBS)

--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ obj/Complex.o: src/Complex.cpp include/Complex.h
 obj/DenseMatrix.o: src/DenseMatrix.cpp include/DenseMatrix.h include/Types.h src/DenseMatrix.inl include/DenseMatrix.h include/LinearContext.h include/Quaternion.h include/Vector.h include/SparseMatrix.h include/Complex.h src/SparseMatrix.inl include/Real.h include/Complex.h include/Utility.h 
 	$(CC) $(CFLAGS) -c src/DenseMatrix.cpp -o obj/DenseMatrix.o
 
-obj/Edge.o: src/Edge.cpp include/Edge.h include/Types.h include/Quaternion.h include/Vector.h include/Complex.h include/Mesh.h include/HalfEdge.h include/Vertex.h include/Edge.h include/Face.h include/AliasTable.h include/Halfedge.h 
+obj/Edge.o: src/Edge.cpp include/Edge.h include/Types.h include/Quaternion.h include/Vector.h include/Complex.h include/Mesh.h include/HalfEdge.h include/Vertex.h include/Edge.h include/Face.h include/AliasTable.h
 	$(CC) $(CFLAGS) -c src/Edge.cpp -o obj/Edge.o
 
 obj/Face.o: src/Face.cpp include/Face.h include/Types.h include/Complex.h include/Vector.h include/Mesh.h include/HalfEdge.h include/Quaternion.h include/Vertex.h include/Edge.h include/Face.h include/AliasTable.h include/Vector.h include/Utility.h 


### PR DESCRIPTION
In one place in the `Makefile`, `include/HalfEdge.h` is referred to as `include/Halfedge.h`. This breaks compilation on some filesystems with the error `make: *** No rule to make target 'include/Halfedge.h', needed by 'obj/Edge.o'.  Stop.`, as make thinks its a target as it cannot find the file.
In addition, on my Ubuntu 18.04 machine, I had to add `-std=c++11` to the CFLAGS.